### PR TITLE
Feat/summary coloring

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -117,6 +117,7 @@ function App() {
         <div className="row g-5">
           <section className="col-lg-6">
             <Summary
+              currentMonth={currentMonth}
               selectedMonth={selectedMonth}
               filteredExpenses={filteredExpenses}
             />

--- a/src/views/Summary.js
+++ b/src/views/Summary.js
@@ -18,22 +18,21 @@ function Summary({ selectedMonth, filteredExpenses }) {
   return (
     <div className="card h-100">
       <h3 className="card-header">
-        Summary for{' '}
-        <span className="text-primary fw-bold">{selectedMonth}</span>
+        Summary for <span className="fw-bold">{selectedMonth}</span>
       </h3>
       <div className="card-body container d-flex flex-column justify-content-between">
         <h4 className="fw-light row">
           <span className="col-6 col-md-4 col-lg-6 col-xl-5">
             Starting budget:
           </span>
-          <span className="col-4 text-success fw-bold text-end">{` ${getUKFormattedEuros(
+          <span className="col-4 fw-bold text-end">{` ${getUKFormattedEuros(
             totalBudget
           )}`}</span>
           <div className="col-3"></div>
         </h4>
         <h4 className="fw-light row">
           <span className="col-6 col-md-4 col-lg-6 col-xl-5">Money spent:</span>
-          <span className="col-4 text-danger fw-bold text-end">{` ${getUKFormattedEuros(
+          <span className="col-4 fw-bold text-end">{` ${getUKFormattedEuros(
             totalExpenses
           )}`}</span>
           <div className="col-3"></div>

--- a/src/views/Summary.js
+++ b/src/views/Summary.js
@@ -65,7 +65,7 @@ function Summary({ currentMonth, selectedMonth, filteredExpenses }) {
           </span>
           <span
             className={`col-4 fw-bold text-end ${
-              spendingRateDeviation >= 0.15
+              spendingRateDeviation >= 0.1
                 ? 'text-danger'
                 : spendingRateDeviation > 0
                 ? 'text-warning'

--- a/src/views/Summary.js
+++ b/src/views/Summary.js
@@ -6,18 +6,17 @@ function Summary({ currentMonth, selectedMonth, filteredExpenses }) {
   const [totalExpenses, setTotalExpenses] = useState(0);
   const [spendingRateDeviation, setSpendingRateDeviation] = useState(0);
 
-  // Calculate total expenses
-  useEffect(() => {
+  const updateTotalExpenses = () => {
     const expenseSum = filteredExpenses
       .map(expense => expense.amount)
       .reduce((sum, curr) => {
         return sum + curr;
       }, 0);
     setTotalExpenses(expenseSum);
-  }, [filteredExpenses]);
+    console.log('Ran updateTotalExpenses');
+  };
 
-  // Calculate spending rate deviation
-  useEffect(() => {
+  const updateSpendingRateDeviation = () => {
     const date = new Date(selectedMonth);
 
     // Get last day of selected month
@@ -35,7 +34,12 @@ function Summary({ currentMonth, selectedMonth, filteredExpenses }) {
     const actualRate = totalExpenses / dayOfMonth;
     const deviation = (actualRate - targetRate) / targetRate;
     setSpendingRateDeviation(deviation);
-  }, [currentMonth, selectedMonth, totalBudget, totalExpenses]);
+  };
+
+  useEffect(() => {
+    updateTotalExpenses();
+    updateSpendingRateDeviation();
+  });
 
   return (
     <div className="card h-100">

--- a/src/views/Summary.js
+++ b/src/views/Summary.js
@@ -1,12 +1,13 @@
 import { useEffect, useState } from 'react';
 import { getUKFormattedEuros } from '../utils/helpers';
 
-function Summary({ selectedMonth, filteredExpenses }) {
+function Summary({ currentMonth, selectedMonth, filteredExpenses }) {
   const [totalBudget, setTotalBudget] = useState(7777 * 100);
   const [totalExpenses, setTotalExpenses] = useState(0);
+  const [spendingRateDeviation, setSpendingRateDeviation] = useState(0);
 
+  // Calculate total expenses
   useEffect(() => {
-    // Calculate total expenses
     const expenseSum = filteredExpenses
       .map(expense => expense.amount)
       .reduce((sum, curr) => {
@@ -14,6 +15,27 @@ function Summary({ selectedMonth, filteredExpenses }) {
       }, 0);
     setTotalExpenses(expenseSum);
   }, [filteredExpenses]);
+
+  // Calculate spending rate deviation
+  useEffect(() => {
+    const date = new Date(selectedMonth);
+
+    // Get last day of selected month
+    const daysInMonth = new Date(
+      date.getFullYear(),
+      date.getMonth() + 1,
+      0
+    ).getDate();
+
+    // Set day equal to today's date or last day of the month
+    const dayOfMonth =
+      selectedMonth === currentMonth ? new Date().getDate() : daysInMonth;
+
+    const targetRate = totalBudget / daysInMonth;
+    const actualRate = totalExpenses / dayOfMonth;
+    const deviation = (actualRate - targetRate) / targetRate;
+    setSpendingRateDeviation(deviation);
+  }, [currentMonth, selectedMonth, totalBudget, totalExpenses]);
 
   return (
     <div className="card h-100">
@@ -41,9 +63,15 @@ function Summary({ selectedMonth, filteredExpenses }) {
           <span className="col-6 col-md-4 col-lg-6 col-xl-5">
             Remaining budget:
           </span>
-          <span className="col-4 text-warning fw-bold text-end">{` ${getUKFormattedEuros(
-            totalBudget - totalExpenses
-          )}`}</span>
+          <span
+            className={`col-4 fw-bold text-end ${
+              spendingRateDeviation >= 0.15
+                ? 'text-danger'
+                : spendingRateDeviation > 0
+                ? 'text-warning'
+                : 'text-success'
+            }`}
+          >{` ${getUKFormattedEuros(totalBudget - totalExpenses)}`}</span>
           <div className="col-3"></div>
         </h4>
       </div>


### PR DESCRIPTION
# Issue #13 

### What was done:
- [x] Removed coloring from all `Summary` elements except for "remaining budget"
- [x] Added feature to calculate spending rate deviation and to conditionally render the remaining budget in green (on budget), yellow (< 15% over budget) or red (15% or more over budget)

# Examples (as of 27 April 2022)

### On budget
Target spending rate = €259.23 / day
Actual spending rate = €259.23 / day
Deviation = 0
![chrome_RMsf2B2yy6](https://user-images.githubusercontent.com/26901435/165451400-a7eb93c1-7ac2-4b18-9741-f7d5533c5320.png)

### Slightly over budget 
Target spending rate = €259.23 / day
Actual spending rate = €259.27 / day
Deviation = 0.014%
![chrome_yPlETgBQiy](https://user-images.githubusercontent.com/26901435/165451645-dfe17c9a-ce97-4c3d-812c-206f78804173.png)

Target spending rate = €259.23 / day
Actual spending rate = ~€287.05 / day
Deviation = 10.7%
![image](https://user-images.githubusercontent.com/26901435/165452883-11a2eaa2-2499-459d-9d55-62eb7b44d720.png)

Target spending rate = €259.23 / day
Actual spending rate = ~€288.04 / day
Deviation = 11.1%
![image](https://user-images.githubusercontent.com/26901435/165453397-622d08bb-855e-4018-bf9e-ebdf8e3dee20.png)

### Over budget
Target spending rate = €259.23 / day
Actual spending rate = ~€306.55 / day
Deviation = 18.3%
![chrome_6lMH4s2HQf](https://user-images.githubusercontent.com/26901435/165455043-d2c5fa6d-b61b-4ffe-a523-7dadbb49ad43.png)

