### PR TITLE
Fix/ux add expense form

### DIFF
--- a/src/views/AddExpenses.js
+++ b/src/views/AddExpenses.js
@@ -58,7 +58,7 @@ const AddExpenses = ({ addExpense, setNewExpenseMonth }) => {
               type="text"
               id="name"
               name="name"
-              placeholder="e.g. 'Groceries'"
+              placeholder="e.g. Groceries"
               aria-describedby="nameHelp"
               required
               autoFocus
@@ -102,7 +102,7 @@ const AddExpenses = ({ addExpense, setNewExpenseMonth }) => {
                 type="number"
                 id="amount"
                 name="amount"
-                placeholder="e.g. '19.99'"
+                placeholder="e.g. 19.99"
                 aria-describedby="amountHelp"
                 required
                 min="0.01"

--- a/src/views/AddExpenses.js
+++ b/src/views/AddExpenses.js
@@ -58,7 +58,7 @@ const AddExpenses = ({ addExpense, setNewExpenseMonth }) => {
               type="text"
               id="name"
               name="name"
-              placeholder="... Groceries ..."
+              placeholder="e.g. 'Groceries'"
               aria-describedby="nameHelp"
               required
               autoFocus
@@ -80,7 +80,7 @@ const AddExpenses = ({ addExpense, setNewExpenseMonth }) => {
               className="form-control"
               id="date"
               name="date"
-              placeholderText="... 01/05/2022 ..."
+              placeholderText="DD/MM/YYYY"
               aria-describedby="dateHelp"
               required
               selected={date}
@@ -102,7 +102,7 @@ const AddExpenses = ({ addExpense, setNewExpenseMonth }) => {
                 type="number"
                 id="amount"
                 name="amount"
-                placeholder="... 19,99 ..."
+                placeholder="e.g. '19.99'"
                 aria-describedby="amountHelp"
                 required
                 min="0.01"

--- a/src/views/AddExpenses.js
+++ b/src/views/AddExpenses.js
@@ -111,9 +111,6 @@ const AddExpenses = ({ addExpense, setNewExpenseMonth }) => {
                 onChange={handleAmountChange}
               />
             </div>
-            <div id="amountHelp" className="form-text">
-              Euro amount (with comma and two decimal places)
-            </div>
           </div>
           <button className="btn btn-primary" type="submit">
             Add


### PR DESCRIPTION
# For issue #28 

### What was done:
- [x] Changed "Expense name" placeholder to _e.g. Groceries_
- [x] Changed "Expense date" placeholder to _DD/MM/YYYY_
- [x] Changed "Expense amount" placeholder to _e.g. 19.99_
- [x] Removed helper text from under the "Expense amount" input

![chrome_9gr8fX3vLo](https://user-images.githubusercontent.com/26901435/170276197-eef69b05-9c90-4772-bf09-9e066c221cce.png)