### PR TITLE
Make "Expense not added" and "Expense not deleted" alerts disappear automatically

### DIFF
--- a/cypress/integration/App.spec.js
+++ b/cypress/integration/App.spec.js
@@ -19,7 +19,7 @@ describe('App', () => {
       .find('.react-datepicker')
       .should('be.visible');
     cy.findByLabelText(/expense date/i).type('2022-02-01{enter}');
-    cy.findByRole('spinbutton', { name: /expense amount in €/i }).type('14.99');
+    cy.findByRole('spinbutton', { name: /expense amount/i }).type('14.99');
     cy.findByRole('button', { name: /add/i }).click();
 
     cy.findByRole('combobox', { name: /select a month/i }).should(
@@ -27,7 +27,7 @@ describe('App', () => {
       'February 2022'
     );
 
-    cy.get('[id="Select month view"]').within(() => {
+    cy.get('[id="New expense added to February 2022"]').within(() => {
       cy.get('[data-cy="okButton"]').click();
     });
 
@@ -39,7 +39,7 @@ describe('App', () => {
       ''
     );
     cy.findByLabelText(/expense date/i).should('have.value', '');
-    cy.findByRole('spinbutton', { name: /expense amount in €/i }).should(
+    cy.findByRole('spinbutton', { name: /expense amount/i }).should(
       'have.value',
       ''
     );
@@ -93,8 +93,11 @@ describe('App', () => {
       .find('.react-datepicker')
       .should('be.visible');
     cy.findByLabelText(/expense date/i).type('2022-05-01{enter}');
-    cy.findByRole('spinbutton', { name: /expense amount in €/i }).type('4.99');
+    cy.findByRole('spinbutton', { name: /expense amount/i }).type('4.99');
     cy.findByRole('button', { name: /add/i }).click();
+
+    // Wait for "Expense added" alert to close
+    cy.findByRole('alert').should('be.visible').wait(5000).should('not.exist');
 
     cy.get('[data-cy="expenses"] > li')
       .should('contain', '01/05/2022')
@@ -109,6 +112,7 @@ describe('App', () => {
       cy.get('[data-cy="okButton"]').click();
     });
 
+    // Wait for "Expense deleted" alert to close
     cy.findByRole('alert').should('be.visible').wait(5000).should('not.exist');
 
     cy.get('[data-cy=expenses]')

--- a/src/App.js
+++ b/src/App.js
@@ -105,12 +105,8 @@ const App = () => {
   };
 
   const removeExpense = async id => {
-    const url = `${baseURL}/items/${id}.json`;
+    const url = `${baseURL}/item/${id}.json`;
     const requestOptions = { method: 'DELETE', headers };
-
-    // Reset alerts in case user did not dismiss them
-    setExpenseAdded(undefined);
-    setExpenseDeleted(undefined);
 
     setConfirmDeleteModalIsOpen(true);
 
@@ -127,11 +123,11 @@ const App = () => {
       if (filteredExpenses.length === 1) setSelectedMonth(currentMonth);
       setExpenseDeleted(true);
       setConfirmDeleteModalIsOpen(false);
-
       closeExpenseDeleteAlert();
     } catch (error) {
       setExpenseDeleted(false);
       setConfirmDeleteModalIsOpen(false);
+      closeExpenseDeleteAlert();
     }
   };
 

--- a/src/App.js
+++ b/src/App.js
@@ -82,10 +82,6 @@ const App = () => {
       body: JSON.stringify(newExpense),
     };
 
-    // Reset alerts in case user did not dismiss them
-    setExpenseAdded(undefined);
-    setExpenseDeleted(undefined);
-
     try {
       const res = await fetch(url, requestOptions);
       const newExpense = await res.json();
@@ -101,10 +97,10 @@ const App = () => {
 
       setExpenses([...expenses, newExpense]);
       setExpenseAdded(true);
-
       closeExpenseAddedAlert();
     } catch (error) {
       setExpenseAdded(false);
+      closeExpenseAddedAlert();
     }
   };
 

--- a/src/App.js
+++ b/src/App.js
@@ -105,7 +105,7 @@ const App = () => {
   };
 
   const removeExpense = async id => {
-    const url = `${baseURL}/item/${id}.json`;
+    const url = `${baseURL}/items/${id}.json`;
     const requestOptions = { method: 'DELETE', headers };
 
     setConfirmDeleteModalIsOpen(true);

--- a/src/components/Modals/ConfirmMonthModal.js
+++ b/src/components/Modals/ConfirmMonthModal.js
@@ -4,7 +4,7 @@ const ConfirmMonthModal = ({ newExpenseMonth, setIsOpen, okCallback }) => {
   const modalProps = {
     cancelCallback: () => setIsOpen(false),
     okCallback: () => okCallback(newExpenseMonth),
-    modalTitle: 'Select month view',
+    modalTitle: 'New expense added',
     cancelButtonLabel: 'Stay here',
     okButtonLabel: `Open ${newExpenseMonth}`,
     okButtonColor: 'btn-primary',
@@ -13,7 +13,8 @@ const ConfirmMonthModal = ({ newExpenseMonth, setIsOpen, okCallback }) => {
   return (
     <Modal {...modalProps}>
       <h6 className="mb-3">
-        Would you like to open the new expense month's history?
+        Your expense has been added. Would you like to switch to the month for
+        this expense?
       </h6>
     </Modal>
   );

--- a/src/components/Modals/ConfirmMonthModal.js
+++ b/src/components/Modals/ConfirmMonthModal.js
@@ -4,7 +4,7 @@ const ConfirmMonthModal = ({ newExpenseMonth, setIsOpen, okCallback }) => {
   const modalProps = {
     cancelCallback: () => setIsOpen(false),
     okCallback: () => okCallback(newExpenseMonth),
-    modalTitle: 'New expense added',
+    modalTitle: `New expense added to ${newExpenseMonth}`,
     cancelButtonLabel: 'Stay here',
     okButtonLabel: `Open ${newExpenseMonth}`,
     okButtonColor: 'btn-primary',

--- a/src/views/AddExpenses.js
+++ b/src/views/AddExpenses.js
@@ -93,7 +93,7 @@ const AddExpenses = ({ addExpense, setNewExpenseMonth }) => {
             className={`col mb-2 ${wasAmountValidated ? 'was-validated' : ''}`}
           >
             <label className="form-label" htmlFor="amount">
-              Expense amount in €
+              Expense amount
             </label>
             <div className="input-group">
               <span className="input-group-text">€</span>


### PR DESCRIPTION
# For Issue #32 

### What was done:
- [x] Modified `addExpense()` to automatically close `<ExpenseAddedAlert />` after 5 seconds when adding fails
- [x] Modified `removeExpense()` to automatically close `<ExpenseDeletedAlert />` after 5 seconds when deleting fails
- [x] Changed the title and body text of `<ConfirmMonthModal />` to allow it to double as confirmation of an expense being successfully added

### Alerts when adding and deleting fail:
https://user-images.githubusercontent.com/26901435/170314097-c56a2cc7-0006-48d6-a16f-6b26c2fcf20f.mp4


### New "Confirm Month" modal
![chrome_whhMvzYKPn](https://user-images.githubusercontent.com/26901435/170314277-00067543-3269-4dfe-b2ca-a86310cfaa49.png)

