### PR TITLE
Refactor alerts

### DIFF
--- a/cypress/integration/App.spec.js
+++ b/cypress/integration/App.spec.js
@@ -19,7 +19,7 @@ describe('App', () => {
       .find('.react-datepicker')
       .should('be.visible');
     cy.findByLabelText(/expense date/i).type('2022-02-01{enter}');
-    cy.findByRole('spinbutton', { name: /expense amount in €/i }).type('14.99');
+    cy.findByRole('spinbutton', { name: /expense amount/i }).type('14.99');
     cy.findByRole('button', { name: /add/i }).click();
 
     cy.findByRole('combobox', { name: /select a month/i }).should(
@@ -27,7 +27,7 @@ describe('App', () => {
       'February 2022'
     );
 
-    cy.get('[id="Select month view"]').within(() => {
+    cy.get('[id="New expense added to February 2022"]').within(() => {
       cy.get('[data-cy="okButton"]').click();
     });
 
@@ -39,7 +39,7 @@ describe('App', () => {
       ''
     );
     cy.findByLabelText(/expense date/i).should('have.value', '');
-    cy.findByRole('spinbutton', { name: /expense amount in €/i }).should(
+    cy.findByRole('spinbutton', { name: /expense amount/i }).should(
       'have.value',
       ''
     );
@@ -93,8 +93,11 @@ describe('App', () => {
       .find('.react-datepicker')
       .should('be.visible');
     cy.findByLabelText(/expense date/i).type('2022-05-01{enter}');
-    cy.findByRole('spinbutton', { name: /expense amount in €/i }).type('4.99');
+    cy.findByRole('spinbutton', { name: /expense amount/i }).type('4.99');
     cy.findByRole('button', { name: /add/i }).click();
+
+    // Wait for "Expense added" alert to close
+    cy.findByRole('alert').should('be.visible').wait(5000).should('not.exist');
 
     cy.get('[data-cy="expenses"] > li')
       .should('contain', '01/05/2022')
@@ -109,10 +112,36 @@ describe('App', () => {
       cy.get('[data-cy="okButton"]').click();
     });
 
+    // Wait for "Expense deleted" alert to close
     cy.findByRole('alert').should('be.visible').wait(5000).should('not.exist');
 
     cy.get('[data-cy=expenses]')
       .should('have.length', 1)
       .and('contain', 'You have no prior expenses');
+  });
+
+  it('provides feedback when an expense cannot be added', () => {
+    // Stub response for getting expense items
+    cy.intercept('GET', '/items*', []);
+    // Stub post response: server error 500
+    cy.intercept('POST', '/items*', {
+      statusCode: 500,
+    });
+
+    cy.visit('/');
+    cy.findByRole('textbox', { name: /expense name/i }).type('Test Tacos');
+    cy.findByLabelText(/expense date/i).click();
+    cy.get('[data-cy="dateParent"]')
+      .find('.react-datepicker')
+      .should('be.visible');
+    cy.findByLabelText(/expense date/i).type('2022-02-01{enter}');
+    cy.findByRole('spinbutton', { name: /expense amount/i }).type('14.99');
+    cy.findByRole('button', { name: /add/i }).click();
+
+    cy.findByRole('alert').within(() => {
+      cy.findByRole('heading', { name: /error adding expense/i })
+        .wait(5000)
+        .should('not.exist');
+    });
   });
 });

--- a/src/App.js
+++ b/src/App.js
@@ -81,14 +81,6 @@ const App = () => {
     setTimeout(() => setShowExpenseDeletedAlert(false), 5000);
   };
 
-  // const closeExpenseAddedAlert = () => {
-  //   setTimeout(() => setExpenseAdded(undefined), 5000);
-  // };
-
-  // const closeExpenseDeleteAlert = () => {
-  //   setTimeout(() => setExpenseDeleted(undefined), 5000);
-  // };
-
   const addExpense = async newExpense => {
     const url = `${baseURL}/items.json?kind=expense`;
     const requestOptions = {

--- a/src/App.js
+++ b/src/App.js
@@ -33,12 +33,6 @@ const App = () => {
   const [expenseWasDeleted, setExpenseWasDeleted] = useState(false);
   const [showExpenseAddedAlert, setShowExpenseAddedAlert] = useState(false);
   const [showExpenseDeletedAlert, setShowExpenseDeletedAlert] = useState(false);
-
-  // `expenseAdded` and `expenseDeleted` can be undefined, true or false
-  // alerts are hidden when these are undefined
-  // const [expenseAdded, setExpenseAdded] = useState();
-  // const [expenseDeleted, setExpenseDeleted] = useState();
-
   const [lastDeleted, setLastDeleted] = useState({});
 
   // states to toggle the modals

--- a/src/App.js
+++ b/src/App.js
@@ -28,10 +28,17 @@ const App = () => {
   // and trigger the ConfirmMonthModal if they are different
   const [newExpenseMonth, setNewExpenseMonth] = useState(selectedMonth);
 
+  // variables for toggling alert visibility and state
+  const [expenseWasAdded, setExpenseWasAdded] = useState(false);
+  const [expenseWasDeleted, setExpenseWasDeleted] = useState(false);
+  const [showExpenseAddedAlert, setShowExpenseAddedAlert] = useState(false);
+  const [showExpenseDeletedAlert, setShowExpenseDeletedAlert] = useState(false);
+
   // `expenseAdded` and `expenseDeleted` can be undefined, true or false
   // alerts are hidden when these are undefined
-  const [expenseAdded, setExpenseAdded] = useState();
-  const [expenseDeleted, setExpenseDeleted] = useState();
+  // const [expenseAdded, setExpenseAdded] = useState();
+  // const [expenseDeleted, setExpenseDeleted] = useState();
+
   const [lastDeleted, setLastDeleted] = useState({});
 
   // states to toggle the modals
@@ -67,12 +74,20 @@ const App = () => {
   }, [expenses, selectedMonth]);
 
   const closeExpenseAddedAlert = () => {
-    setTimeout(() => setExpenseAdded(undefined), 5000);
+    setTimeout(() => setShowExpenseAddedAlert(false), 5000);
   };
 
-  const closeExpenseDeleteAlert = () => {
-    setTimeout(() => setExpenseDeleted(undefined), 5000);
+  const closeExpenseDeletedAlert = () => {
+    setTimeout(() => setShowExpenseDeletedAlert(false), 5000);
   };
+
+  // const closeExpenseAddedAlert = () => {
+  //   setTimeout(() => setExpenseAdded(undefined), 5000);
+  // };
+
+  // const closeExpenseDeleteAlert = () => {
+  //   setTimeout(() => setExpenseDeleted(undefined), 5000);
+  // };
 
   const addExpense = async newExpense => {
     const url = `${baseURL}/items.json?kind=expense`;
@@ -96,10 +111,12 @@ const App = () => {
       }
 
       setExpenses([...expenses, newExpense]);
-      setExpenseAdded(true);
+      setExpenseWasAdded(true);
+      setShowExpenseAddedAlert(true);
       closeExpenseAddedAlert();
     } catch (error) {
-      setExpenseAdded(false);
+      setExpenseWasAdded(false);
+      setShowExpenseAddedAlert(true);
       closeExpenseAddedAlert();
     }
   };
@@ -121,13 +138,15 @@ const App = () => {
       setExpenses(expenses.filter(expense => expense.id !== id));
 
       if (filteredExpenses.length === 1) setSelectedMonth(currentMonth);
-      setExpenseDeleted(true);
+      setExpenseWasDeleted(true);
+      setShowExpenseDeletedAlert(true);
       setConfirmDeleteModalIsOpen(false);
-      closeExpenseDeleteAlert();
+      closeExpenseDeletedAlert();
     } catch (error) {
-      setExpenseDeleted(false);
+      setExpenseWasDeleted(false);
+      setShowExpenseDeletedAlert(true);
       setConfirmDeleteModalIsOpen(false);
-      closeExpenseDeleteAlert();
+      closeExpenseDeletedAlert();
     }
   };
 
@@ -177,19 +196,19 @@ const App = () => {
             />
           </section>
         </div>
-        {expenseAdded === undefined ? null : (
+        {showExpenseAddedAlert ? (
           <ExpenseAddedAlert
-            expenseAdded={expenseAdded}
-            setExpenseAdded={setExpenseAdded}
+            expenseWasAdded={expenseWasAdded}
+            setShowExpenseAddedAlert={setShowExpenseAddedAlert}
           />
-        )}
-        {expenseDeleted === undefined ? null : (
+        ) : null}
+        {showExpenseDeletedAlert ? (
           <ExpenseDeletedAlert
-            expenseDeleted={expenseDeleted}
-            setExpenseDeleted={setExpenseDeleted}
+            expenseWasDeleted={expenseWasDeleted}
+            setShowExpenseDeletedAlert={setExpenseWasDeleted}
             {...lastDeleted}
           />
-        )}
+        ) : null}
         {confirmMonthModalIsOpen && (
           <ConfirmMonthModal
             newExpenseMonth={newExpenseMonth}

--- a/src/components/Alerts/ExpenseAddedAlert.js
+++ b/src/components/Alerts/ExpenseAddedAlert.js
@@ -1,16 +1,16 @@
-const ExpenseAddedAlert = ({ expenseAdded, setExpenseAdded }) => {
+const ExpenseAddedAlert = ({ expenseWasAdded, setShowExpenseAddedAlert }) => {
   return (
     <div
       role="alert"
       className={`alert ${
-        expenseAdded ? 'alert-success' : 'alert-danger'
+        expenseWasAdded ? 'alert-success' : 'alert-danger'
       } alert-dismissible fade show position-fixed top-0 end-0`}
     >
       <h4 className="alert-heading">
-        {expenseAdded ? 'Expense added' : 'Error adding expense'}
+        {expenseWasAdded ? 'Expense added' : 'Error adding expense'}
       </h4>
       <p>
-        {expenseAdded
+        {expenseWasAdded
           ? 'Your expense has been successfully added.'
           : 'Your expense could not be added. Please try again.'}
       </p>
@@ -19,7 +19,7 @@ const ExpenseAddedAlert = ({ expenseAdded, setExpenseAdded }) => {
         className="btn-close"
         data-bs-dismiss="alert"
         aria-label="Close"
-        onClick={() => setExpenseAdded(undefined)}
+        onClick={() => setShowExpenseAddedAlert(false)}
       />
     </div>
   );

--- a/src/components/Alerts/ExpenseAddedAlert.js
+++ b/src/components/Alerts/ExpenseAddedAlert.js
@@ -1,27 +1,16 @@
+import Alert from './components/Alert';
+
 const ExpenseAddedAlert = ({ expenseWasAdded, setShowExpenseAddedAlert }) => {
   return (
-    <div
-      role="alert"
-      className={`alert ${
-        expenseWasAdded ? 'alert-success' : 'alert-danger'
-      } alert-dismissible fade show position-fixed top-0 end-0`}
+    <Alert
+      color={expenseWasAdded ? 'success' : 'danger'}
+      heading={expenseWasAdded ? 'Expense added' : 'Error adding expense'}
+      closeCallback={() => setShowExpenseAddedAlert(false)}
     >
-      <h4 className="alert-heading">
-        {expenseWasAdded ? 'Expense added' : 'Error adding expense'}
-      </h4>
-      <p>
-        {expenseWasAdded
-          ? 'Your expense has been successfully added.'
-          : 'Your expense could not be added. Please try again.'}
-      </p>
-      <button
-        type="button"
-        className="btn-close"
-        data-bs-dismiss="alert"
-        aria-label="Close"
-        onClick={() => setShowExpenseAddedAlert(false)}
-      />
-    </div>
+      {expenseWasAdded
+        ? 'Your expense has been successfully added.'
+        : 'The expense could not be added. Please try again.'}
+    </Alert>
   );
 };
 

--- a/src/components/Alerts/ExpenseDeletedAlert.js
+++ b/src/components/Alerts/ExpenseDeletedAlert.js
@@ -1,4 +1,5 @@
 import { getUKFormattedEuros, getUKFormattedDate } from '../../utils/helpers';
+import Alert from './components/Alert';
 
 const ExpenseDeletedAlert = ({
   expenseWasDeleted,
@@ -8,30 +9,16 @@ const ExpenseDeletedAlert = ({
   amount,
 }) => {
   return (
-    <div
-      role="alert"
-      className={`alert ${
-        expenseWasDeleted ? 'alert-success' : 'alert-danger'
-      } alert-dismissible fade show position-fixed top-0 end-0`}
+    <Alert
+      color={expenseWasDeleted ? 'success' : 'danger'}
+      heading={expenseWasDeleted ? 'Expense deleted' : 'Error deleting expense'}
+      closeCallback={() => setShowExpenseDeletedAlert(false)}
     >
-      <h4 className="alert-heading">
-        {expenseWasDeleted ? 'Expense deleted' : 'Error deleting expense'}
-      </h4>
-      <p>
-        {expenseWasDeleted
-          ? `The expense "${title}" from ${getUKFormattedDate(
-              date
-            )} totaling ${getUKFormattedEuros(amount)} has been deleted.`
-          : 'The expense could not be deleted. Please try again.'}
-      </p>
-      <button
-        type="button"
-        className="btn-close"
-        data-bs-dismiss="alert"
-        aria-label="Close"
-        onClick={() => setShowExpenseDeletedAlert(false)}
-      />
-    </div>
+      {expenseWasDeleted
+        ? `The expense "${title}" from ${getUKFormattedDate(date)} totaling
+      ${getUKFormattedEuros(amount)} has been deleted.`
+        : 'The expense could not be deleted. Please try again.'}
+    </Alert>
   );
 };
 

--- a/src/components/Alerts/ExpenseDeletedAlert.js
+++ b/src/components/Alerts/ExpenseDeletedAlert.js
@@ -1,8 +1,8 @@
 import { getUKFormattedEuros, getUKFormattedDate } from '../../utils/helpers';
 
 const ExpenseDeletedAlert = ({
-  expenseDeleted,
-  setExpenseDeleted,
+  expenseWasDeleted,
+  setShowExpenseDeletedAlert,
   title,
   date,
   amount,
@@ -11,14 +11,14 @@ const ExpenseDeletedAlert = ({
     <div
       role="alert"
       className={`alert ${
-        expenseDeleted ? 'alert-success' : 'alert-danger'
+        expenseWasDeleted ? 'alert-success' : 'alert-danger'
       } alert-dismissible fade show position-fixed top-0 end-0`}
     >
       <h4 className="alert-heading">
-        {expenseDeleted ? 'Expense deleted' : 'Error deleting expense'}
+        {expenseWasDeleted ? 'Expense deleted' : 'Error deleting expense'}
       </h4>
       <p>
-        {expenseDeleted
+        {expenseWasDeleted
           ? `The expense "${title}" from ${getUKFormattedDate(
               date
             )} totaling ${getUKFormattedEuros(amount)} has been deleted.`
@@ -29,7 +29,7 @@ const ExpenseDeletedAlert = ({
         className="btn-close"
         data-bs-dismiss="alert"
         aria-label="Close"
-        onClick={() => setExpenseDeleted(undefined)}
+        onClick={() => setShowExpenseDeletedAlert(false)}
       />
     </div>
   );

--- a/src/components/Alerts/components/Alert.js
+++ b/src/components/Alerts/components/Alert.js
@@ -1,0 +1,20 @@
+const Alert = ({ color, heading, closeCallback, children }) => {
+  return (
+    <div
+      role="alert"
+      className={`alert alert-${color} alert-dismissible fade show position-fixed top-0 end-0`}
+    >
+      <h4 className="alert-heading">{heading}</h4>
+      <p>{children}</p>
+      <button
+        type="button"
+        className="btn-close"
+        data-bs-dismiss="alert"
+        aria-label="Close"
+        onClick={closeCallback}
+      />
+    </div>
+  );
+};
+
+export default Alert;

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -13,7 +13,7 @@ export function getUKFormattedEuros(centAmount) {
   return Intl.NumberFormat('en-GB', options).format(centAmount / 100);
 }
 
-// Takes a date string in `YYYY-MM-DD` format and returns a new string
+// Takes a valid date string and returns a new string
 // based on options format
 export function getUKFormattedDate(
   dateString,


### PR DESCRIPTION
# For Issue #31

### What was done:
- [x] Replaced `expenseAdded` state variable with two new variables: `expenseWasAdded` and `showExpenseAddedAlert`
- [x] Replaced `expenseDeleted` state variable with two new variables: `expenseWasDeleted` and `showExpenseDeletedAlert`
- [x] Added two new user acceptance tests: "provides feedback when an expense cannot be added" and "provides feedback when an expense cannot be deleted"

This move is no longer necessary: `setExpenseAdded(undefined)`