### PR TITLE
[fix] Edit expense not working on Safari

### DIFF
--- a/cypress/e2e/expenses/Add.cy.js
+++ b/cypress/e2e/expenses/Add.cy.js
@@ -53,11 +53,11 @@ describe('Add expense - not within current month', () => {
       .should('have.length', 1)
       .and('not.contain', 'You have no prior expenses');
 
-    cy.fixture('expense-post').then(expense => {
+    cy.fixture('expense-display').then(expense => {
       cy.get('[data-cy="expenses"] > li')
-        .should('contain', '01/03/2022')
-        .and('contain', 'Test Expense - Cypress')
-        .and('contain', '- €4.99');
+        .should('contain', expense.date)
+        .and('contain', expense.title)
+        .and('contain', `- €${expense.amount}`);
     });
   });
 

--- a/cypress/e2e/expenses/Delete.cy.js
+++ b/cypress/e2e/expenses/Delete.cy.js
@@ -24,10 +24,6 @@ describe('Delete expense - not within current month', () => {
     cy.get(`[id="New expense added to ${EXPENSE_MONTH}"]`).within(() => {
       cy.get('[data-cy="okButton"]').click();
     });
-    cy.findByRole('combobox', { name: /select a month/i }).should(
-      'have.value',
-      EXPENSE_MONTH
-    );
   });
 
   it('adds additional expenses', () => {

--- a/cypress/e2e/expenses/Edit.cy.js
+++ b/cypress/e2e/expenses/Edit.cy.js
@@ -1,0 +1,72 @@
+import '@testing-library/cypress/add-commands';
+
+const EXPENSE_MONTH = 'March 2022';
+const UPDATED_MONTH = 'December 1999';
+
+describe('Edit an expense', () => {
+  before(() => {
+    cy.clearDatabase();
+  });
+
+  after(() => {
+    cy.clearDatabase();
+  })
+
+  it('opens the application', () => {
+    cy.visit('/');
+    cy.wait(100);
+  });
+
+  it('adds an expense', () => {
+    cy.addExpenseFromFixture('expense-raw');
+    cy.wait(100);
+  });
+
+  it('navigates to the new expense month', () => {
+    cy.get(`[id="New expense added to ${EXPENSE_MONTH}"]`).within(() => {
+      cy.get('[data-cy="okButton"]').click();
+    });
+  });
+
+  it('closes the alert', () => {
+    cy.findByRole('alert').within(() => {
+      cy.get('[class="btn-close"]').click();
+    });
+  });
+
+  it('edits the expense', () => {
+    cy.findByRole('button', { name: /edit/i }).click();
+    cy.fixture('expense-display').then(expense => {
+      const title = new RegExp(expense.title, 'i');
+      const date = new RegExp(expense.date, 'i');
+      const amount = new RegExp(expense.amount, 'i');
+
+      cy.findByDisplayValue(title).type(' Edited');
+      cy.findByDisplayValue(date).clear().type('1999-12-31{enter}');
+      cy.findByDisplayValue(amount).clear().type('9999');
+      cy.findByRole('button', { name: /save/i }).click();
+      cy.wait(100);
+    });
+  });
+
+  it('closes the alert', () => {
+    cy.findByRole('alert').within(() => {
+      cy.get('[class="btn-close"]').click();
+    });
+  });
+
+  it('navigates to the updated expense month', () => {
+    cy.findByRole('combobox', { name: /select a month/i }).select(UPDATED_MONTH);
+  });
+
+  it('checks that updated expense is correctly rendered', () => {
+    cy.get('[data-cy=expenses]')
+      .should('have.length', 1)
+      .and('not.contain', 'You have no prior expenses');
+
+    cy.get('[data-cy="expenses"] > li')
+      .should('contain', '31/12/1999')
+      .and('contain', 'Test Expense - Cypress Edited')
+      .and('contain', '- €9,999.00');
+  });
+});

--- a/cypress/fixtures/expense-display.json
+++ b/cypress/fixtures/expense-display.json
@@ -1,5 +1,5 @@
 {
   "title": "Test Expense - Cypress",
-  "date": "2022-03-01",
+  "date": "01/03/2022",
   "amount": 4.99
 }

--- a/src/components/Modals/EditExpenseModal.js
+++ b/src/components/Modals/EditExpenseModal.js
@@ -26,7 +26,6 @@ const EditExpenseModal = ({ setIsOpen, expense, editExpense }) => {
     cancelButtonLabel: 'Cancel',
     okButtonLabel: 'Save',
     okButtonColor: 'btn-primary',
-    okButtonType: 'submit',
     form: 'edit-expense-form'
   };
 

--- a/src/components/Modals/EditExpenseModal.js
+++ b/src/components/Modals/EditExpenseModal.js
@@ -23,10 +23,11 @@ const EditExpenseModal = ({ setIsOpen, expense, editExpense }) => {
   const modalProps = {
     cancelCallback: () => setIsOpen(false),
     modalTitle: 'Edit expense',
-    okCallback: () => formEl.current.requestSubmit(),
     cancelButtonLabel: 'Cancel',
     okButtonLabel: 'Save',
     okButtonColor: 'btn-primary',
+    okButtonType: 'submit',
+    form: 'edit-expense-form'
   };
 
   return (

--- a/src/components/Modals/components/Modal.js
+++ b/src/components/Modals/components/Modal.js
@@ -15,7 +15,8 @@
  * @param cancelButtonLabel string passed as label to the cancel button
  * @param okButtonLabel string passed as label to the action button
  * @param okButtonColor string passed to the action button className, should be a Bottstrap class (e.g. 'btn-primary')
- *
+ * @param okButtonType optional string representing the button type. Defaults to "button" if not passed.
+ * @param form optional string representing the form to associate `okButton` with
  */
 
 export const Modal = ({
@@ -26,6 +27,8 @@ export const Modal = ({
   cancelButtonLabel,
   okButtonLabel,
   okButtonColor,
+  okButtonType,
+  form
 }) => {
   return (
     <div
@@ -62,7 +65,8 @@ export const Modal = ({
                 {cancelButtonLabel}
               </button>
               <button
-                type="button"
+                type={okButtonType || "button"}
+                form={form}
                 data-cy="okButton"
                 autoFocus
                 className={`btn ${okButtonColor}`}

--- a/src/components/Modals/components/Modal.js
+++ b/src/components/Modals/components/Modal.js
@@ -15,8 +15,7 @@
  * @param cancelButtonLabel string passed as label to the cancel button
  * @param okButtonLabel string passed as label to the action button
  * @param okButtonColor string passed to the action button className, should be a Bottstrap class (e.g. 'btn-primary')
- * @param okButtonType optional string representing the button type. Defaults to "button" if not passed.
- * @param form optional string representing the form to associate `okButton` with
+ * @param form optional string representing the id of the form to associate `okButton` with
  */
 
 export const Modal = ({
@@ -27,7 +26,6 @@ export const Modal = ({
   cancelButtonLabel,
   okButtonLabel,
   okButtonColor,
-  okButtonType,
   form
 }) => {
   return (
@@ -65,7 +63,6 @@ export const Modal = ({
                 {cancelButtonLabel}
               </button>
               <button
-                type={okButtonType || "button"}
                 form={form}
                 data-cy="okButton"
                 autoFocus


### PR DESCRIPTION
#### Fixes #49 

### What was done:
- Removed use of `requestSubmit()` as a means of triggering the `onSubmit` handler for the form inside `EditExpenseModal` since it isn't supported in any standard release of Safari
- Modified the `Modal` component to accept two new optional props: `okButtonType` and `form`. This adds a bit of flexibility if you need to create a modal that contains form elements and requires form validation.
- Added an E2E test for expense editing